### PR TITLE
Added date math calculations for amber class

### DIFF
--- a/column-samples/date-range-rag/date-range-rag.json
+++ b/column-samples/date-range-rag/date-range-rag.json
@@ -2,110 +2,180 @@
     "$schema": "http://columnformatting.sharepointpnp.com/columnFormattingSchema.json",
     "elmType": "div",
     "style": {
-      "position": "relative"
+        "position": "relative"
     },
     "children": [
-      {
-        "elmType": "div",
-        "attributes": {
-          "class": {
-            "operator": "?",
-            "operands": [
-              {
-                "operator": "<=",
-                "operands": [
-                  "[$DueDate]",
-                  "@now"
-                ]
-              },
-              "sp-field-severity--severeWarning",
-              "sp-field-severity--good"
-            ]
-          }
-        },
-        "style": {
-          "min-height": "inherit",
-          "width": {
-            "operator": "?",
-            "operands": [
-              {
-                "operator": "<=",
-                "operands": [
-                  "[$DueDate]",
-                  "@now"
-                ]
-              },
-              "100%",
-              {
-                "operator": "+",
-                "operands": [
-                  {
-                    "operator": "-",
+        {
+            "elmType": "div",
+            "attributes": {
+                "class": {
+                    "operator": "?",
                     "operands": [
-                      100,
-                      {
-                        "operator": "*",
-                        "operands": [
-                          {
-                            "operator": "/",
+                        {
+                            "operator": "<=",
                             "operands": [
-                              {
-                                "operator": "/",
-                                "operands": [
-                                  {
-                                    "operator": "Number()",
-                                    "operands": [
-                                      {
-                                        "operator": "-",
-                                        "operands": [
-                                          "[$DueDate]",
-                                          "@now"
-                                        ]
-                                      }
-                                    ]
-                                  },
-                                  86400000
-                                ]
-                              },
-                              {
-                                "operator": "/",
-                                "operands": [
-                                  {
-                                    "operator": "Number()",
-                                    "operands": [
-                                      {
-                                        "operator": "-",
-                                        "operands": [
-                                          "[$DueDate]",
-                                          "[$StartDate]"
-                                        ]
-                                      }
-                                    ]
-                                  },
-                                  86400000
-                                ]
-                              }
+                                "[$DueDate]",
+                                "@now"
                             ]
-                          },
-                          100
-                        ]
-                      }
+                        },
+                        "sp-field-severity--severeWarning",
+                        {
+                            "operator":"?",
+                            "operands": [
+                                {
+                                    "operator": ">",
+                                    "operands": [
+                                        {
+                                            "operator": "+",
+                                            "operands": [
+                                                {
+                                                    "operator": "-",
+                                                    "operands": [
+                                                        100,
+                                                        {
+                                                            "operator": "*",
+                                                            "operands": [
+                                                                {
+                                                                    "operator": "/",
+                                                                    "operands": [
+                                                                        {
+                                                                            "operator": "/",
+                                                                            "operands": [
+                                                                                {
+                                                                                    "operator": "Number()",
+                                                                                    "operands": [
+                                                                                        {
+                                                                                            "operator": "-",
+                                                                                            "operands": [
+                                                                                                "[$DueDate]",
+                                                                                                "@now"
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                86400000
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "operator": "/",
+                                                                            "operands": [
+                                                                                {
+                                                                                    "operator": "Number()",
+                                                                                    "operands": [
+                                                                                        {
+                                                                                            "operator": "-",
+                                                                                            "operands": [
+                                                                                                "[$DueDate]",
+                                                                                                "[$StartDate]"
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                86400000
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                100
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "%"
+                                            ]
+                                        },
+                                        "70%"
+                                    ]
+                                },
+                                "sp-field-severity--warning",
+                                "sp-field-severity--good"
+                            ]
+                        }
                     ]
-                  },
-                  "%"
-                ]
-              }
-            ]
-          }
+                }
+            },
+            "style": {
+                "min-height": "inherit",
+                "width": {
+                    "operator": "?",
+                    "operands": [
+                        {
+                            "operator": "<=",
+                            "operands": [
+                                "[$DueDate]",
+                                "@now"
+                            ]
+                        },
+                        "100%",
+                        {
+                            "operator": "+",
+                            "operands": [
+                                {
+                                    "operator": "-",
+                                    "operands": [
+                                        100,
+                                        {
+                                            "operator": "*",
+                                            "operands": [
+                                                {
+                                                    "operator": "/",
+                                                    "operands": [
+                                                        {
+                                                            "operator": "/",
+                                                            "operands": [
+                                                                {
+                                                                    "operator": "Number()",
+                                                                    "operands": [
+                                                                        {
+                                                                            "operator": "-",
+                                                                            "operands": [
+                                                                                "[$DueDate]",
+                                                                                "@now"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                86400000
+                                                            ]
+                                                        },
+                                                        {
+                                                            "operator": "/",
+                                                            "operands": [
+                                                                {
+                                                                    "operator": "Number()",
+                                                                    "operands": [
+                                                                        {
+                                                                            "operator": "-",
+                                                                            "operands": [
+                                                                                "[$DueDate]",
+                                                                                "[$StartDate]"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                86400000
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                100
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "%"
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "elmType": "span",
+            "txtContent": "@currentField",
+            "style": {
+                "position": "absolute"
+            }
         }
-      },
-      {
-        "elmType": "span",
-        "txtContent": "@currentField",
-        "style": {
-          "position": "absolute",
-          "left": "4px"
-        }
-      }
     ]
-  }
+}


### PR DESCRIPTION
I didn't see the amber class getting worked into the class assignment expression, so I copied the width expression's date math comparison up to include the sp-field-severity--warning class.

| Q               | A
| --------------- | ---
| Bug fix?        | No
| New sample?      | No
| Related issues?  |  Fixes amber class not being added.

#### What's in this Pull Request?

I just copied up the date math stuff so the amber class would get applied.