### PR TITLE
Update for "Icon" field reference

### DIFF
--- a/view-samples/generic-tile-format/tile-view.json
+++ b/view-samples/generic-tile-format/tile-view.json
@@ -44,7 +44,7 @@
               {
                 "elmType": "div",
                 "attributes": {
-                  "iconName": "[$j9js]",
+                  "iconName": "[$Icon]",
                   "class": "ms-fontSize-su"
                 }
               }


### PR DESCRIPTION
Updating the "iconName" field to properly reference the field name of "Icon" identified in the README.
https://github.com/SharePoint/sp-dev-list-formatting/issues/93

| Q               | A
| --------------- | ---
| Bug fix?        | yes?

| Related issues?  | fixes #93

#### What's in this Pull Request?

Updated the JSON to properly reflect the "Icon" field name provided in the Readme. There was a field name reference that was different then what was included in the README. :)

Credit to @LouFarho

Thanks for your contribution! Sharing is caring.