### PR TITLE
Fix syntax error

### DIFF
--- a/view-samples/document-library/README.md
+++ b/view-samples/document-library/README.md
@@ -4,7 +4,7 @@
 
 SharePoint is at its best when using lightweight structure and process to organize content and keep things moving forward.  New to Document Libraries is an out of the box Flow that allows you to quickly request a member of your team to sign off on a document in a Dcument Library.  This sample defines a custom view to bring focus to the files that need to be approved.  It also provides a better visual indication of where documents are in the process and which ones require action.
 
-###Desktop and tablet view
+### Desktop and tablet view
 
 ![Document Library Sample](images/document-library.jpg)
 
@@ -12,13 +12,13 @@ SharePoint is at its best when using lightweight structure and process to organi
 
 The view must include these columns:
 
-###Standard columns
+### Standard columns
 
 - LinkFilename
 - Editor
 - Modified
 
-###Custom columns
+### Custom columns
 
 Column Name|Type
 -----------|----
@@ -73,7 +73,7 @@ The View Formatter JSON ([card-format.json](card-format.json)) defines a button 
                 },
 ````
 
-###Authors
+### Authors
 
 - Tyler Lui (Canviz) @TylerLu
 - Justin So (Canviz)

--- a/view-samples/resource-catalog/README.md
+++ b/view-samples/resource-catalog/README.md
@@ -10,12 +10,12 @@ SharePoint lists are excellent places to store information.  This example demons
 
 The view must include these columns:
 
-###Standard columns
+### Standard columns
 
 - LinkTitle
 - Modified
 
-###Custom columns
+### Custom columns
 
 Column Name|Type
 -----------|----
@@ -31,7 +31,7 @@ This sample includes a site script ([create-list.json](create-list.json)) that c
 
 See the [SharePoint site design and site script overview article](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview) to learn how to use the site script.
 
-###Authors
+### Authors
 
 - Tyler Lui (Canviz) @TylerLu
 - Justin So (Canviz)


### PR DESCRIPTION
There should be a space between the sharp and the title in GitHub Markdown syntax

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

Add a space between the sharp and title, such that GitHub can render the title correctly.
