### PR TITLE
Added SP2019 warnings to formats that are not applicable

### DIFF
--- a/column-samples/generic-rowactions/README.md
+++ b/column-samples/generic-rowactions/README.md
@@ -24,6 +24,8 @@ This action will prompt the user with a deletion confirmation dialog and delete 
 ### executeFlow
 This action will launch a flow for the item as the selected item. This action requires additional configuration through the `actionParams` property. The ID is always required, but you can also optionally include `headerText` and/or `runFlowButtonText` properties as well to customize the Flow panel.
 
+>Note - the `headerText` and `runFlowButtonText` parameters are not available in SharePoint 2019
+
 #### To obtain a Flow's ID:
 
 1. Click _Flow_ > _See your flows_ in the SharePoint list where the Flow is configured

--- a/column-samples/multi-choice-foreach/README.md
+++ b/column-samples/multi-choice-foreach/README.md
@@ -8,6 +8,7 @@ This sample demonstrates usage of the `forEach` property to create template elem
 
 ## View requirements
 - This format can be applied to a Multi-Select Choice column
+- This format uses operators only available in SharePoint Online and cannot be used in SharePoint 2019
 
 ## Sample
 

--- a/column-samples/multi-choice-icons/README.md
+++ b/column-samples/multi-choice-icons/README.md
@@ -33,6 +33,7 @@ We can use the `join` or `toString` functions on the value first and then nest t
 
 ## View requirements
 - This format can be applied to a Multi-Select Choice column
+- This format uses operators only available in SharePoint Online and cannot be used in SharePoint 2019
 
 ### Sample Choice Values
 - Water

--- a/column-samples/multi-person-currentuser/README.md
+++ b/column-samples/multi-person-currentuser/README.md
@@ -11,6 +11,7 @@ The [Office UI Fabric](https://developer.microsoft.com/en-us/fabric) theme color
 
 ## View requirements
 - This format can be applied to a Person column
+- This format uses operators only available in SharePoint Online and cannot be used in SharePoint 2019
 
 ## Sample
 

--- a/column-samples/multi-person-facepile/README.md
+++ b/column-samples/multi-person-facepile/README.md
@@ -23,6 +23,7 @@ Overall, however, the L size shouldn't be used inside columns not only because t
 
 ## View requirements
 - This format can be applied to a Multi-Select Person column
+- This format uses operators only available in SharePoint Online and cannot be used in SharePoint 2019
 
 ## Sample
 

--- a/column-samples/number-abs-tolerance-comparison/readME.md
+++ b/column-samples/number-abs-tolerance-comparison/readME.md
@@ -17,7 +17,7 @@ An Office UI Fabric class and icon is also applied to provide visual indicators 
 The columns used in this sample were created as "Number" column types.
 
 ## View requirements
-- N/A
+- This format uses operators only available in SharePoint Online and cannot be used in SharePoint 2019
 
 ## Sample
 

--- a/column-samples/text-contains/README.md
+++ b/column-samples/text-contains/README.md
@@ -25,6 +25,7 @@ Notice that the `indexOf` function is **case-sensitive**. You can do a case-inse
 
 ## View requirements
 - This format can be applied to a Text or Choice column
+- This format uses operators only available in SharePoint Online and cannot be used in SharePoint 2019
 
 ## Sample
 

--- a/column-samples/text-startswith-callingcodes/README.md
+++ b/column-samples/text-startswith-callingcodes/README.md
@@ -24,6 +24,7 @@ Notice that the `indexOf` function is **case-sensitive**. You can do a case-inse
 
 ## View requirements
 - This format can be applied to a Text or Choice column
+- This format uses operators only available in SharePoint Online and cannot be used in SharePoint 2019
 
 ## Sample
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | No
| New sample?      | No
| Related issues?  | fixes #148 

#### What's in this Pull Request?

Added warnings to column formatting samples that use operators not available in SharePoint 2019.