### PR TITLE
Added box-sizing:border-box to number-data-bar sample formats

### DIFF
--- a/column-samples/number-data-bar/README.md
+++ b/column-samples/number-data-bar/README.md
@@ -30,6 +30,7 @@ Version|Date|Comments
 1.0|November 2, 2017|Initial release
 1.1|May 27, 2018|Fixed issue with 0 values and added percentage format
 1.2|August 18, 2018|Fixed issue with low value text wrapping and converted to excel-style expressions
+1.3|May 17, 2019|Added box-sizing:border-box to root style
 
 ## Disclaimer
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**

--- a/column-samples/number-data-bar/number-data-bar.json
+++ b/column-samples/number-data-bar/number-data-bar.json
@@ -16,6 +16,7 @@
   },
   "style": {
     "padding": "0",
-    "width": "=if(@currentField >= 20, '100%', (@currentField * 5) + '%')"
+    "width": "=if(@currentField >= 20, '100%', (@currentField * 5) + '%')",
+    "box-sizing": "border-box"
   }
 }

--- a/column-samples/number-data-bar/number-data-barAST.json
+++ b/column-samples/number-data-bar/number-data-barAST.json
@@ -41,6 +41,7 @@
           ]
         }
       ]
-    }
+    },
+    "box-sizing": "border-box"
   }
 }

--- a/column-samples/number-data-bar/percent-data-bar.json
+++ b/column-samples/number-data-bar/percent-data-bar.json
@@ -16,6 +16,7 @@
   },
   "style": {
     "padding": "0",
-		"width": "=if(@currentField > 1, '100%', if(@currentField < 0, '0', (100 * @currentField) + '%'))"
+    "width": "=if(@currentField > 1, '100%', if(@currentField < 0, '0', (100 * @currentField) + '%'))",
+    "box-sizing": "border-box"
   }
 }

--- a/column-samples/number-data-bar/percent-data-barAST.json
+++ b/column-samples/number-data-bar/percent-data-barAST.json
@@ -71,6 +71,7 @@
           ]
         }
       ]
-    }
+    },
+    "box-sizing": "border-box"
   }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New sample?      | no
| Related issues?  | fixes #153 

#### What's in this Pull Request?

Added `"box-sizing": "border-box"` to each of the number-data-bar sample formats to prevent the format from unnecessarily growing the row size.